### PR TITLE
Adjust dependency on StructureTemplates to new version

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -11,7 +11,7 @@
         },
         {
             "id" : "StructureTemplates",
-            "minVersion" : "0.1.0-SNAPSHOT"
+            "minVersion" : "0.2.0-SNAPSHOT"
         },
         {
             "id" : "StructuralResources",


### PR DESCRIPTION
May need additional tweaks in the actual prefabs for templates - the way facing is handling has changed. See http://forum.terasology.org/threads/structure-templates.1550/page-2#post-14536 for details

May want to pull this then test locally to get the buildings working again if they do not vs latest :-)